### PR TITLE
Allowing format specific options

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,30 @@ Icons without codepoints will have codepoints incremented from `startCodepoint` 
 Options that are passed directly to
 [svgicons2svgfont](https://github.com/nfroidure/svgicons2svgfont).
 
+### formatOptions
+
+Type: `object`
+
+Specific per format arbitrary options to pass to the generator
+
+format and matching generator:
+- `svg` - [svgicons2svgfont](https://github.com/nfroidure/svgicons2svgfont).
+- `ttf` - [svg2ttf](https://github.com/fontello/svg2ttf).
+- `woff` - [ttf2woff](https://github.com/fontello/ttf2woff).
+- `eot` - [ttf2eot](https://github.com/fontello/ttf2eot).
+
+```js
+webfontsGenerator({
+  // options
+  formatOptions: {
+  	// options to pass specifically to the ttf generator
+  	ttf: {
+  		ts: 1451512800000
+  	}
+  }
+}, function(error, result) {})
+```
+
 ### writeFiles
 
 Type: `boolean`

--- a/src/generateFonts.js
+++ b/src/generateFonts.js
@@ -26,8 +26,8 @@ var generators = {
 				'fontName', 'fontHeight', 'descent', 'normalize', 'round'
 			)
 		
-			if (options.formatOptions['ttf']) {
-				svgOptions = _.extend(svgOptions, options.formatOptions['ttf'])
+			if (options.formatOptions['svg']) {
+				svgOptions = _.extend(svgOptions, options.formatOptions['svg'])
 			}
 			
 			svgOptions.log = function(){}
@@ -58,8 +58,7 @@ var generators = {
 	ttf: {
 		deps: ['svg'],
 		fn: function(options, svgFont, done) {
-			var formatOptions = options.formatOptions['ttf'];
-			var font = svg2ttf(svgFont, formatOptions)
+			var font = svg2ttf(svgFont, options.formatOptions['ttf'])
 			font = new Buffer(font.buffer)
 			done(null, font)
 		}
@@ -68,8 +67,7 @@ var generators = {
 	woff: {
 		deps: ['ttf'],
 		fn: function(options, ttfFont, done) {
-			var formatOptions = options.formatOptions['woff'];
-			var font = ttf2woff(new Uint8Array(ttfFont), formatOptions)
+			var font = ttf2woff(new Uint8Array(ttfFont), options.formatOptions['woff'])
 			font = new Buffer(font.buffer)
 			done(null, font)
 		}
@@ -78,8 +76,7 @@ var generators = {
 	eot: {
 		deps: ['ttf'],
 		fn: function(options, ttfFont, done) {
-			var formatOptions = options.formatOptions['eot'];
-			var font = ttf2eot(new Uint8Array(ttfFont), formatOptions)
+			var font = ttf2eot(new Uint8Array(ttfFont), options.formatOptions['eot'])
 			font = new Buffer(font.buffer)
 			done(null, font)
 		}

--- a/src/generateFonts.js
+++ b/src/generateFonts.js
@@ -25,6 +25,11 @@ var generators = {
 			var svgOptions = _.pick(options,
 				'fontName', 'fontHeight', 'descent', 'normalize', 'round'
 			)
+		
+			if (options.formatOptions['ttf']) {
+				svgOptions = _.extend(svgOptions, options.formatOptions['ttf'])
+			}
+			
 			svgOptions.log = function(){}
 
 			var fontStream = svgicons2svgfont(svgOptions)
@@ -53,7 +58,8 @@ var generators = {
 	ttf: {
 		deps: ['svg'],
 		fn: function(options, svgFont, done) {
-			var font = svg2ttf(svgFont)
+			var formatOptions = options.formatOptions['ttf'];
+			var font = svg2ttf(svgFont, formatOptions)
 			font = new Buffer(font.buffer)
 			done(null, font)
 		}
@@ -62,7 +68,8 @@ var generators = {
 	woff: {
 		deps: ['ttf'],
 		fn: function(options, ttfFont, done) {
-			var font = ttf2woff(new Uint8Array(ttfFont))
+			var formatOptions = options.formatOptions['woff'];
+			var font = ttf2woff(new Uint8Array(ttfFont), formatOptions)
 			font = new Buffer(font.buffer)
 			done(null, font)
 		}
@@ -71,7 +78,8 @@ var generators = {
 	eot: {
 		deps: ['ttf'],
 		fn: function(options, ttfFont, done) {
-			var font = ttf2eot(new Uint8Array(ttfFont))
+			var formatOptions = options.formatOptions['eot'];
+			var font = ttf2eot(new Uint8Array(ttfFont), formatOptions)
 			font = new Buffer(font.buffer)
 			done(null, font)
 		}

--- a/src/index.js
+++ b/src/index.js
@@ -32,6 +32,7 @@ var DEFAULT_OPTIONS = {
 	rename: function(file) {
 		return path.basename(file, path.extname(file))
 	},
+	formatOptions: {},
 	/**
 	 * Unicode Private Use Area start.
 	 * http://en.wikipedia.org/wiki/Private_Use_(Unicode)


### PR DESCRIPTION
There is a use case where `ts` option needs to be passed down.
at the moment there is no way to pass options to the actual font generation module.

the PR adds a `formatOptions` object that allows passing arbitrary options to the specific format generator.

with the additions, the usage would be as follows:
```javascript
var webfontsGenerator = require('webfonts-generator')

webfontsGenerator({
  formatOptions: {
    // options to pass specifically to the ttf generator
    ttf: {
        ts: 1451512800000
    }
  }
}, function(error, result) {})
```