### PR TITLE
baseSelector instead of baseClass for template options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Features:
 
 * Supported font formats: WOFF, EOT, TTF and SVG.
 * Supported browsers: IE8+.
-* Generates CSS files and HTML preview, allows to use custom templates. 
+* Generates CSS files and HTML preview, allows to use custom templates.
 
 ## Install
 
@@ -172,7 +172,7 @@ Default options are:
 ```js
 {
 	classPrefix: 'icon-',
-	baseClass: 'icon'
+	baseSelector: '.icon'
 }
 ```
 

--- a/src/index.js
+++ b/src/index.js
@@ -63,6 +63,17 @@ var webfont = function(options, done) {
 		options.htmlDest = path.join(options.dest, options.fontName + '.html')
 	}
 
+	// Warn about using deprecated template options.
+	for(var key in options.templateOptions) {
+		var value = options.templateOptions[key];
+		if(key === "baseClass") {
+			console.warn("[webfont-generator] Using deprecated templateOptions 'baseClass'. Use 'baseSelector' instead.");
+			options.templateOptions.baseSelector = "." + value;
+			delete options.templateOptions.baseClass;
+			break;
+		}
+	}
+
 	options.templateOptions = _.extend({}, DEFAULT_TEMPLATE_OPTIONS, options.templateOptions)
 
 	// Generates codepoints starting from `options.startCodepoint`,

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ var TEMPLATES = {
 }
 
 var DEFAULT_TEMPLATE_OPTIONS = {
-	baseClass: 'icon',
+	baseSelector: '.icon',
 	classPrefix: 'icon-'
 }
 

--- a/templates/css.hbs
+++ b/templates/css.hbs
@@ -3,11 +3,11 @@
 	src: {{{src}}};
 }
 
-.{{baseClass}} {
+{{baseSelector}} {
 	line-height: 1;
 }
 
-.{{baseClass}}:before {
+{{baseSelector}}:before {
 	font-family: {{fontName}} !important;
 	font-style: normal;
 	font-weight: normal !important;


### PR DESCRIPTION
I changed the template options `baseClass` to `baseSelector` for more flexibility. `baseClass` can still be used, but it gives a warning for using it.

In a project I'm working on we use our base selector for our icon font something similar to `[class^=icon-]` so using `baseClass` didn't work for us. I did use a hack specifying `baseClass` something similar to `icon, [class^=icon-]`, but I don't like hacky solutions.
