### PR TITLE
problem occurs when baseSelector contains selector like [class^=icon-]

### DIFF
--- a/templates/css.hbs
+++ b/templates/css.hbs
@@ -3,11 +3,11 @@
 	src: {{{src}}};
 }
 
-{{baseSelector}} {
+{{{baseSelector}}} {
 	line-height: 1;
 }
 
-{{baseSelector}}:before {
+{{{baseSelector}}}:before {
 	font-family: {{fontName}} !important;
 	font-style: normal;
 	font-weight: normal !important;


### PR DESCRIPTION
fix(css): use "triple-stash" to fully escape the html syntax for the baseSelector. 