### PR TITLE
Add support for passing multiple glyph codes for a single icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,15 @@ Type: `object`
 Specific codepoints for certain icons.
 Icons without codepoints will have codepoints incremented from `startCodepoint` skipping duplicates.
 
+```js
+{
+    "my-foo-icon": 0xf0f0, // Single glyph unicode code as a hex number
+    "bar-icon": [0xff01, 0xff99], // You can pass multiple glyph codes for the same icon
+    "moo-icon": 65433 // or use a decimal number value
+}
+
+```
+
 ### fontName, normalize, fontHeight, round, descent
 
 Options that are passed directly to

--- a/src/generateFonts.js
+++ b/src/generateFonts.js
@@ -44,14 +44,20 @@ var generators = {
 			_.each(options.files, function(file, idx) {
 				var glyph = fs.createReadStream(file)
 				var name = options.names[idx]
-				var unicode = String.fromCharCode(options.codepoints[name])
+				var unicodes = options.codepoints[name]
                 var ligature = ''
                 for(var i=0;i<name.length;i++) {
                     ligature+=String.fromCharCode(name.charCodeAt(i))
                 }
+
+                var codes = (Array.isArray(unicodes) ? unicodes : [ unicodes ])
+					.map(function(unicode) {
+						return String.fromCharCode(unicode)
+					});
+
 				glyph.metadata = {
 					name: name,
-					unicode: [unicode,ligature]
+					unicode: codes.concat(ligature)
 				}
 				fontStream.write(glyph)
 			})

--- a/src/renderCss.js
+++ b/src/renderCss.js
@@ -52,7 +52,9 @@ var makeSrc = function(options, urls) {
 
 var makeCtx = function(options, urls) {
 	// Transform codepoints to hex strings
-	var codepoints = _.object(_.map(options.codepoints, function(codepoint, name) {
+	var codepoints = _.object(_.map(options.codepoints, function(codepoints, name) {
+		var codepoint = Array.isArray(codepoints) ? codepoints[0] : codepoints
+
 		return [name, codepoint.toString(16)]
 	}))
 


### PR DESCRIPTION
The [`svgicons2svgfont`](https://github.com/nfroidure/svgicons2svgfont) tool allows you to pass the multiple glyph codes for the same icon.

Example from their page:

```js
// Multiple unicode values are possible
const glyph2 = fs.createReadStream('icons/icon1.svg');
glyph2.metadata = {
  unicode: ['\uE002', '\uEA02'],
  name: 'icon2'
};
```

I wanted to add the same support to `webfonts-generator`.

The changes are backwards compatible, so as a user of this library you don't need to change anything - no breaking changes.