### PR TITLE
Adds generateHtml method to the results object

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ Default: `true`
 It is possible to not create files and get generated fonts in object
  to write them to files later.
 <br>
-Also results object will have function `generateCss([urls])`
+Also results object will have `generateCss([urls])` and `generateHtml()` functions
 where `urls` is an object with future fonts urls.
 
 ```js

--- a/src/index.js
+++ b/src/index.js
@@ -102,6 +102,9 @@ var webfont = function(options, done) {
 			result.generateCss = function(urls) {
 				return renderCss(options, urls)
 			}
+			result.generateHtml = function() {
+				return renderHtml(options)
+			}
 			done(null, result)
 		})
 		.catch(function(err) { done(err) })

--- a/tests/test.js
+++ b/tests/test.js
@@ -74,6 +74,9 @@ describe('webfont', function() {
 			assert.equal(typeof result.generateCss, 'function')
 			var css = result.generateCss()
 			assert.equal(typeof css, 'string')
+			assert.equal(typeof result.generateHtml, 'function')
+			var html = result.generateHtml()
+			assert.equal(html, 'string')
 		})
 	})
 


### PR DESCRIPTION
Similarly to `generateCss()`, it could be useful to generate an html file without writing files to the disk.