### PR TITLE
Implement 'getCodepoints' method on the generator result Object

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,8 +258,7 @@ Default: `true`
 It is possible to not create files and get generated fonts in object
  to write them to files later.
 <br>
-Also results object will have function `generateCss([urls])`
-where `urls` is an object with future fonts urls.
+Also results object will have functions `generateCss([urls])` (where `urls` is an object with future fonts urls.) and `getCodepoints()` which allow you to implement your own writing method.
 
 ```js
 webfontsGenerator({
@@ -268,6 +267,7 @@ webfontsGenerator({
 }, function(error, result) {
   // result.eot, result.ttf, etc - generated fonts
   // result.generateCss(urls) - function to generate css
+  // result.getCodepoints() - function to extract the codepoints map
 })
 ```
 

--- a/src/index.js
+++ b/src/index.js
@@ -99,9 +99,14 @@ var webfont = function(options, done) {
 		.then(function(result) {
 			if (options.writeFiles) writeResult(result, options)
 
+			result.getCodepoints = function () {
+				return options.codepoints;
+			}
+
 			result.generateCss = function(urls) {
 				return renderCss(options, urls)
 			}
+
 			done(null, result)
 		})
 		.catch(function(err) { done(err) })

--- a/tests/test.js
+++ b/tests/test.js
@@ -66,7 +66,7 @@ describe('webfont', function() {
 		})
 	})
 
-	it('returns object with fonts and function generateCss()', function() {
+	it('returns object with fonts, generateCss() and getCodepoints() methods', function(done) {
 		webfontsGenerator(OPTIONS, function(err, result) {
 			assert(result.svg)
 			assert(result.ttf)
@@ -74,14 +74,21 @@ describe('webfont', function() {
 			assert.equal(typeof result.generateCss, 'function')
 			var css = result.generateCss()
 			assert.equal(typeof css, 'string')
+
+			assert.equal(typeof result.getCodepoints, 'function')
+			assert(_.isEqual(Object.keys(result.getCodepoints()), ['back', 'close', 'triangleDown']))
+			assert.equal(typeof result.getCodepoints().back, 'number')
+
+			done()
 		})
 	})
 
-	it('function generateCss can change urls', function() {
+	it('function generateCss can change urls', function(done) {
 		webfontsGenerator(OPTIONS, function(err, result) {
 			var urls = {svg: 'AAA', ttf: 'BBB', woff: 'CCC', eot: 'DDD'}
 			var css = result.generateCss(urls)
 			assert(css.indexOf('AAA') !== -1)
+			done()
 		})
 	})
 


### PR DESCRIPTION
Hi @sunflowerdeath - I'm maintaining a small cli utility using `webfonts-generator` as core - one of the functionalities it implements is optionally rendering a `json` file containing all codepoints mapped to the  icon names.

The way I'm currently obtaining that is by parsing the output CSS and re-mapping it to a JS object, though it's quite a hacky way and it means it will not parse correctly when passing in a custom CSS template, as it's currently based on CSS rules regex.

Exposing a method on the `results` object that returns the raw map of codepoints would make this process a lot cleaner and may also be handy to other people wanting to do something different with the library.

The PR includes a test and addition to readme, it should be minimum amount of work to get it out - let me know if you think it's something we can get merged and published or whether I can contribute another way.

Thanks!